### PR TITLE
[HOTFIX] h5p upload fix

### DIFF
--- a/server/routes/chapters.js
+++ b/server/routes/chapters.js
@@ -111,7 +111,7 @@ router.delete('/:id', permController.requireAuth, permController.grantAccess('de
 
 router.post('/:id/upload', async ctx => {
   const dirName = ctx.params.id;
-  const uploadPath = `uploads/H5P/${dirName}`;
+  const uploadPath = `uploads/h5p/${dirName}`;
   const uploadDir = path.resolve(__dirname, '../public/' + uploadPath);
 
   await busboy(ctx.req, {


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request targets the `master` branch of Wikonnect.
- [x] My pull request passes all test.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
change h5p upload folder from the capitalized one to a lowercase folder name
This was in conflict with the request for a h5p.json resource in the ```h5p``` folder and the server had a `H5P` folder name
