### PR TITLE
Social share links

### DIFF
--- a/frontend/app/components/social-share-links.hbs
+++ b/frontend/app/components/social-share-links.hbs
@@ -1,15 +1,44 @@
 {{yield}}
-<div>
-    <a class="twitter-share-button" href="https://twitter.com/intent/tweet?text=Hello%20world">
-        Tweet
-    </a>
-</div>
-<!-- Facebook Link share -->
-<div id="fb-root"></div>
-<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
 
-<div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-size="large">
-    <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">
-        Share
-    </a>
+<div class="social-share-links">
+    <script>
+        window.twttr = (function(d, s, id) {
+            var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {};
+            if (d.getElementById(id)) return t;
+            js = d.createElement(s);
+            js.id = id;
+            js.src = "https://platform.twitter.com/widgets.js";
+            fjs.parentNode.insertBefore(js, fjs);
+            t._e = [];
+            t.ready = function(f) {
+                t._e.push(f);
+            };
+            return t;
+            }
+            (document, "script", "twitter-wjs")
+        );
+    </script>
+    <div>
+        <a class="twitter-share-button" data-size="large">
+            Tweet
+        </a>
+    </div>
+
+
+    <div id="fb-root"></div>
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
+
+    <div class="fb-share-button" data-layout="button" data-size="large">
+        <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{@currenturl}};src=sdkpreparse" class="fb-xfbml-parse-ignore">
+            Share
+        </a>
+    </div>
+
+    <script>
+        App.ShareTwitterComponent = Ember.Component.extend({
+            tagName: 'a',
+            classNames: 'twitter-share-button',
+            attributeBindings: ['data-size', 'data-url', 'data-text', 'data-hashtags']
+        });
+    </script>
 </div>

--- a/frontend/app/components/social-share-links.hbs
+++ b/frontend/app/components/social-share-links.hbs
@@ -1,0 +1,15 @@
+{{yield}}
+<div>
+    <a class="twitter-share-button" href="https://twitter.com/intent/tweet?text=Hello%20world">
+        Tweet
+    </a>
+</div>
+<!-- Facebook Link share -->
+<div id="fb-root"></div>
+<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
+
+<div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-size="large">
+    <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse" class="fb-xfbml-parse-ignore">
+        Share
+    </a>
+</div>

--- a/frontend/app/components/social-share-links.hbs
+++ b/frontend/app/components/social-share-links.hbs
@@ -2,43 +2,18 @@
 
 <div class="social-share-links">
     <script>
-        window.twttr = (function(d, s, id) {
-            var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {};
-            if (d.getElementById(id)) return t;
-            js = d.createElement(s);
-            js.id = id;
-            js.src = "https://platform.twitter.com/widgets.js";
-            fjs.parentNode.insertBefore(js, fjs);
-            t._e = [];
-            t.ready = function(f) {
-                t._e.push(f);
-            };
-            return t;
-            }
-            (document, "script", "twitter-wjs")
-        );
+        window.twttr = (function(d, s, id) {var js, fjs = d.getElementsByTagName(s)[0], t = window.twttr || {}; if (d.getElementById(id)) return t; js = d.createElement(s); js.id = id; js.src = "https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js, fjs); t._e = [];t.ready = function(f) {t._e.push(f);};return t;} (document, "script", "twitter-wjs"));
     </script>
+
+    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
+    
     <div>
-        <a class="twitter-share-button" data-size="large">
-            Tweet
-        </a>
+        <a class="twitter-share-button" data-size="large">Tweet</a>
     </div>
 
 
     <div id="fb-root"></div>
-    <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v6.0"></script>
-
     <div class="fb-share-button" data-layout="button" data-size="large">
-        <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{@currenturl}};src=sdkpreparse" class="fb-xfbml-parse-ignore">
-            Share
-        </a>
+        <a target="_blank" src=sdkpreparse" class="fb-xfbml-parse-ignore">Share</a>
     </div>
-
-    <script>
-        App.ShareTwitterComponent = Ember.Component.extend({
-            tagName: 'a',
-            classNames: 'twitter-share-button',
-            attributeBindings: ['data-size', 'data-url', 'data-text', 'data-hashtags']
-        });
-    </script>
 </div>

--- a/frontend/tests/integration/components/social-share-links-test.js
+++ b/frontend/tests/integration/components/social-share-links-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | social-share-links', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<SocialShareLinks />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <SocialShareLinks>
+        template block text
+      </SocialShareLinks>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [X] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [X] My pull request targets the `master` branch of Wikonnect.
- [x] My pull request passes all test.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #84

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
I have create a component 'social-share-links.hbs' that has a twitter and facebook share button.
The Twitter and Facebook buttons when clicked are preloaded with the URL to be share.
Facebook button shows that the url is invalid because it is a localhost url but if you check the url at the address bar, the url is loading properly. 
This component can be easily embeded on any template by using: {{social-share-links}} .
