### PR TITLE
 [WIK-61] [FEATURE] [FRONTEND] Add reactions component on homepage chapter card and single chapter view

### DIFF
--- a/cypress/fixtures/chapters.json
+++ b/cypress/fixtures/chapters.json
@@ -20,19 +20,48 @@
     "contentId": null,
     "approved": "true",
     "topics": null,
-    "likes": "1",
-    "dislikes": "4",
     "rating": "3.6666666666666667",
     "flag": [],
+    "reaction": {
+      "likes": 3,
+      "authenticated_user": "like",
+      "dislikes": 1
+    },
+    "achievement": [
+      {
+        "id": "achievements2",
+        "target": "chapter1",
+        "targetStatus": "completed",
+        "type": "achievement"
+      },
+      {
+        "id": "achievements4",
+        "target": "chapter1",
+        "targetStatus": "completed",
+        "type": "achievement"
+      },
+      {
+        "id": "achievements7",
+        "target": "chapter1",
+        "targetStatus": "started",
+        "type": "achievement"
+      },
+      {
+        "id": "achievements8",
+        "target": "chapter1",
+        "targetStatus": "attempted",
+        "type": "achievement"
+      }
+    ],
     "comment": [
       {
-        "id": "ItiSBfqAAAc",
+        "id": "It40-WKAAAc",
         "creatorId": "user1",
         "comment": "chapter1",
         "type": "comment"
       },
       {
-        "id": "ItiSBfqAAAg",
+        "id": "It40-WMAAAg",
         "creatorId": "user1",
         "comment": "chapter1",
         "type": "comment"
@@ -60,19 +89,36 @@
     "contentId": null,
     "approved": "true",
     "topics": null,
-    "likes": "3",
-    "dislikes": "3",
     "rating": null,
     "flag": [],
+    "reaction": {
+      "likes": 0,
+      "authenticated_user": "dislike",
+      "dislikes": 3
+    },
+    "achievement": [
+      {
+        "id": "achievements1",
+        "target": "chapter2",
+        "targetStatus": "completed",
+        "type": "achievement"
+      },
+      {
+        "id": "achievements3",
+        "target": "chapter2",
+        "targetStatus": "completed",
+        "type": "achievement"
+      }
+    ],
     "comment": [
       {
-        "id": "ItiSBfqAAAk",
+        "id": "It40-WMAAAk",
         "creatorId": "user2",
         "comment": "chapter2",
         "type": "comment"
       },
       {
-        "id": "ItiSBfqAAAo",
+        "id": "It40-WMAAAo",
         "creatorId": "user3",
         "comment": "chapter2",
         "type": "comment"
@@ -100,10 +146,17 @@
     "contentId": null,
     "approved": "true",
     "topics": null,
-    "likes": "0",
-    "dislikes": "0",
     "rating": null,
     "flag": [],
+    "reaction": [],
+    "achievement": [
+      {
+        "id": "achievements5",
+        "target": "chapter4",
+        "targetStatus": "completed",
+        "type": "achievement"
+      }
+    ],
     "comment": []
   },
   {
@@ -127,10 +180,10 @@
     "contentId": null,
     "approved": "true",
     "topics": null,
-    "likes": "0",
-    "dislikes": "0",
     "rating": null,
     "flag": [],
+    "reaction": [],
+    "achievement": [],
     "comment": []
   }
 ]

--- a/cypress/integration/chapter/reaction.spec.js
+++ b/cypress/integration/chapter/reaction.spec.js
@@ -1,0 +1,143 @@
+import chapters from '../../fixtures/chapters.json'
+
+describe('Chapter Reaction Without Auth', () => {
+
+    function newChapter() {
+        return chapters.find((chapter) => !chapter.reaction.authenticated_user);
+    }
+
+    it('Should see chapter reactions', () => {
+        const {id} = newChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .should('be.visible');
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .should('be.visible');
+    });
+
+    it('Should not like a chapter', () => {
+        const {id} = newChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .like-button')
+            .click();
+
+        cy.get('.reactions .like-button .count')
+            .contains(0);
+
+    });
+
+    it('Should not dislike a chapter', () => {
+        const {id} = newChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .dislike-button')
+            .click();
+
+        cy.get('.reactions .dislike-button .count')
+            .contains(0);
+
+    });
+})
+
+
+describe('Chapter Reaction After Auth', () => {
+
+    beforeEach(() => {
+        cy.login();
+    })
+
+    function likedChapter() {
+        return chapters.find((chapter) => chapter.reaction.authenticated_user === 'like');
+    }
+
+    function dislikedChapter() {
+        return chapters.find((chapter) => chapter.reaction.authenticated_user === 'dislike');
+    }
+
+    function newChapter() {
+        return chapters.find((chapter) => !chapter.reaction.authenticated_user);
+    }
+
+    it('Should see chapter reactions', () => {
+        const {id} = newChapter();
+        cy.visit(`/home/`)
+            .get(`a[href="/chapter/${id}"]:first`)
+            .click();
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .should('be.visible')
+            .contains(0);
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .should('be.visible')
+            .contains(0);
+    });
+
+    it('Should like a chapter', () => {
+        const {id, reaction} = newChapter();
+        cy.visit(`/home/`)
+            .get(`a[href="/chapter/${id}"]:first`)
+            .click();
+
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .click()
+            .find('.count')
+            .contains((reaction.likes || 0) + 1);
+    });
+
+    it('Should dislike a chapter', () => {
+        const {id, reaction} = newChapter();
+        cy.visit(`/home/`)
+            .get(`a[href="/chapter/${id}"]:first`)
+            .click();
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .click()
+            .find('.count')
+            .contains((reaction.dislikes || 0) + 1);
+    });
+
+    it('Should switch disliked chapter reaction', () => {
+        const {id, reaction} = dislikedChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .click()
+            .visit('/home')
+            .visit(`/chapter/${id}`);
+
+        cy.get('.reactions .like-button .count')
+            .contains(reaction.likes + 1);
+
+        cy.get('.reactions .dislike-button .count')
+            .contains(reaction.dislikes - 1);
+    });
+
+    it('Should switch liked chapter reaction', () => {
+        const {id, reaction} = likedChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .click()
+            .visit('/home')
+            .visit(`/chapter/${id}`);
+
+
+        cy.get('.reactions .like-button .count')
+            .contains(reaction.likes - 1);
+
+        cy.get('.reactions .dislike-button .count')
+            .contains(reaction.dislikes + 1);
+    });
+
+})
+

--- a/cypress/integration/chapter/reaction.spec.js
+++ b/cypress/integration/chapter/reaction.spec.js
@@ -66,9 +66,7 @@ describe('Chapter Reaction After Auth', () => {
 
     it('Should see chapter reactions', () => {
         const {id} = newChapter();
-        cy.visit(`/home/`)
-            .get(`a[href="/chapter/${id}"]:first`)
-            .click();
+        cy.visit(`/chapter/${id}`);
 
         cy.get('.reactions .reaction-btn.like-button')
             .should('be.visible')
@@ -81,10 +79,7 @@ describe('Chapter Reaction After Auth', () => {
 
     it('Should like a chapter', () => {
         const {id, reaction} = newChapter();
-        cy.visit(`/home/`)
-            .get(`a[href="/chapter/${id}"]:first`)
-            .click();
-
+        cy.visit(`/chapter/${id}`);
 
         cy.get('.reactions .reaction-btn.like-button')
             .click()
@@ -94,9 +89,7 @@ describe('Chapter Reaction After Auth', () => {
 
     it('Should dislike a chapter', () => {
         const {id, reaction} = newChapter();
-        cy.visit(`/home/`)
-            .get(`a[href="/chapter/${id}"]:first`)
-            .click();
+        cy.visit(`/chapter/${id}`);
 
         cy.get('.reactions .reaction-btn.dislike-button')
             .click()
@@ -110,9 +103,7 @@ describe('Chapter Reaction After Auth', () => {
         cy.visit(`/chapter/${id}`);
 
         cy.get('.reactions .reaction-btn.like-button')
-            .click()
-            .visit('/home')
-            .visit(`/chapter/${id}`);
+            .click();
 
         cy.get('.reactions .like-button .count')
             .contains(reaction.likes + 1);
@@ -127,9 +118,7 @@ describe('Chapter Reaction After Auth', () => {
         cy.visit(`/chapter/${id}`);
 
         cy.get('.reactions .reaction-btn.dislike-button')
-            .click()
-            .visit('/home')
-            .visit(`/chapter/${id}`);
+            .click();
 
 
         cy.get('.reactions .like-button .count')
@@ -139,5 +128,32 @@ describe('Chapter Reaction After Auth', () => {
             .contains(reaction.dislikes + 1);
     });
 
+    it('Should retract previous liked chapter reaction', () => {
+        const { id, reaction } = likedChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .click()
+            .find(' .count')
+            .contains(reaction.likes - 1);
+
+        cy.get('.reactions .dislike-button .count')
+            .contains(reaction.dislikes);
+    });
+
+    it('Should retract previous disliked chapter reaction', () => {
+        const { id, reaction } = dislikedChapter();
+
+        cy.visit(`/chapter/${id}`);
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .click()
+            .find(' .count')
+            .contains(reaction.dislikes - 1);
+
+        cy.get('.reactions .like-button .count')
+            .contains(reaction.likes);
+    });
 })
 

--- a/cypress/integration/home/reaction.spec.js
+++ b/cypress/integration/home/reaction.spec.js
@@ -1,0 +1,67 @@
+import chapters from "../../fixtures/chapters.json";
+
+describe('Homepage Chapter Reactions After Auth', () => {
+
+    beforeEach(() => {
+        cy.login();
+        cy.visit('/home');
+    })
+
+    function newChapter() {
+        return chapters.find((chapter) => !chapter.reaction.authenticated_user);
+    }
+
+
+    it('Should see chapter reactions', () => {
+        cy.login();
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .should('be.visible');
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .should('be.visible');
+    });
+
+
+    it('Should not like a chapter', () => {
+        const {id, reaction} = newChapter();
+
+        cy.get(`.card a[href="/chapter/${id}"]:first`)
+            .siblings()
+            .find('.reactions')
+            .find('.like-button')
+            .click()
+            .find('.count')
+            .contains((reaction.likes)||0);
+    });
+
+    it('Should not dislike a chapter', () => {
+        const {id, reaction} = newChapter();
+
+        cy.get(`.card a[href="/chapter/${id}"]:first`)
+            .siblings()
+            .find('.reactions')
+            .find('.dislike-button')
+            .click()
+            .find('.count')
+            .contains((reaction.likes)||0);
+    });
+
+})
+
+describe('Homepage Chapter Reactions Without Auth', () => {
+
+    beforeEach(() => {
+        cy.visit('/home')
+    })
+
+    it('Should see chapter reactions', () => {
+
+        cy.get('.reactions .reaction-btn.like-button')
+            .should('be.visible');
+
+        cy.get('.reactions .reaction-btn.dislike-button')
+            .should('be.visible');
+    });
+
+})

--- a/frontend/app/components/h5p-list-item.hbs
+++ b/frontend/app/components/h5p-list-item.hbs
@@ -8,8 +8,19 @@
         <img class="card-img-top" alt="" src={{@chapter.imageUrl}}>
       {{/if}}
     {{/link-to}}
-    <div class="card-body">
-      <h5 class="card-title">
+    <div class="card-body chapter-body">
+      <div class="actions-section d-flex justify-content-between">
+        <div class="reactions">
+          <Reaction::ChapterReaction  @chapter={{@chapter}} @canReact={{false}}>
+
+          </Reaction::ChapterReaction>
+        </div>
+        <div class="popup-actions">
+
+        </div>
+      </div>
+
+      <h5 class="card-title title-section">
 
         {{#link-to "chapter" @chapter.id }}
 

--- a/frontend/app/components/reaction/chapter-reaction.hbs
+++ b/frontend/app/components/reaction/chapter-reaction.hbs
@@ -1,10 +1,10 @@
-<button class="reaction-btn {{if this.hasLiked "active" ""}}"
+<button class="reaction-btn {{if this.hasLiked "active" ""}} like-button"
   {{on "click" (fn this.userChapterReaction this.chapter true)}}>
   <MdIcon @icon="thumb-up" @size="15"/>
   <span class="count"> {{this.likes}} </span>
 </button>
 
-<button class="reaction-btn {{if this.hasDisliked "active" ""}}"
+<button class="reaction-btn {{if this.hasDisliked "active" ""}} dislike-button"
   {{on "click" (fn this.userChapterReaction this.chapter false)}}>
   <MdIcon @icon="thumb-down" @size="15"/>
   <span class="count"> {{this.dislikes}}</span>

--- a/frontend/app/components/reaction/chapter-reaction.hbs
+++ b/frontend/app/components/reaction/chapter-reaction.hbs
@@ -1,0 +1,11 @@
+<button class="reaction-btn {{if this.hasLiked "active" ""}}"
+  {{on "click" (fn this.userChapterReaction this.chapter true)}}>
+  <MdIcon @icon="thumb-up" @size="15"/>
+  <span class="count"> {{this.likes}} </span>
+</button>
+
+<button class="reaction-btn {{if this.hasDisliked "active" ""}}"
+  {{on "click" (fn this.userChapterReaction this.chapter false)}}>
+  <MdIcon @icon="thumb-down" @size="15"/>
+  <span class="count"> {{this.dislikes}}</span>
+</button>

--- a/frontend/app/components/reaction/chapter-reaction.js
+++ b/frontend/app/components/reaction/chapter-reaction.js
@@ -50,9 +50,6 @@ export default class ReactionChapterReactionComponent extends Component {
       return;
     }
 
-    console.log(this.hasDisliked,this.hasDisliked);
-
-
     //if they have none, post
     if (!this.hasLiked && !this.hasDisliked) {
       return this.createUserChapterReaction(chapter, liked)
@@ -104,7 +101,6 @@ export default class ReactionChapterReactionComponent extends Component {
   }
 
   updateChapterReactions(chapter, likesIncrement, dislikesIncrement = 0) {
-    console.log(likesIncrement, dislikesIncrement);
     this.likes += likesIncrement;
     this.dislikes += dislikesIncrement;
   }

--- a/frontend/app/components/reaction/chapter-reaction.js
+++ b/frontend/app/components/reaction/chapter-reaction.js
@@ -9,9 +9,9 @@ export default class ReactionChapterReactionComponent extends Component {
   @service store;
 
   @tracked
-  likes = this.args.chapter.reaction.likes || 0;
+  likes = Array.isArray(this.args.chapter.reaction) ? 0 : this.args.chapter.reaction.likes || 0;
   @tracked
-  dislikes = this.args.chapter.reaction.dislikes || 0;
+  dislikes = Array.isArray(this.args.chapter.reaction) ? 0 : this.args.chapter.reaction?.dislikes || 0;
 
   get chapter() {
     return this.args.chapter;
@@ -19,11 +19,13 @@ export default class ReactionChapterReactionComponent extends Component {
 
 
   @tracked
-  hasLiked = (!this.me.isAuthenticated || !this.chapter?.reaction?.authenticated_user) ? false :
+  hasLiked = (!this.me.isAuthenticated ||Array.isArray(this.args.chapter.reaction)||
+    !this.chapter?.reaction?.authenticated_user) ? false :
     this.chapter.reaction.authenticated_user === 'like';
 
   @tracked
-  hasDisliked = (!this.me.isAuthenticated || !this.chapter?.reaction?.authenticated_user) ? false :
+  hasDisliked = (!this.me.isAuthenticated ||Array.isArray(this.args.chapter.reaction)||
+    !this.chapter?.reaction?.authenticated_user) ? false :
     this.chapter.reaction.authenticated_user === 'dislike';
 
 

--- a/frontend/app/components/reaction/chapter-reaction.js
+++ b/frontend/app/components/reaction/chapter-reaction.js
@@ -1,0 +1,112 @@
+import Component from '@glimmer/component';
+import {inject as service} from '@ember/service';
+import {action} from '@ember/object';
+import {tracked} from '@glimmer/tracking';
+
+export default class ReactionChapterReactionComponent extends Component {
+
+  @service me;
+  @service store;
+
+  @tracked
+  likes = this.args.chapter.reaction.likes || 0;
+  @tracked
+  dislikes = this.args.chapter.reaction.dislikes || 0;
+
+  get chapter() {
+    return this.args.chapter;
+  }
+
+  get currentUserReaction() {
+    return this.store.peekAll('reaction')
+      .find((r) => (r.user.get('id') === this.me.user.id && r.chapter.get('id') === this.args.chapter.id));
+  }
+
+  get hasLiked() {
+    if (!this.me.isAuthenticated) {
+      return false;
+    }
+    const obj = this.currentUserReaction;
+    if (!obj) {
+      return false;
+    }
+    return obj.reaction === 'like';
+  }
+
+  get hasDisliked() {
+    if (!this.me.isAuthenticated) {
+      return false;
+    }
+    const obj = this.currentUserReaction;
+    if (!obj) {
+      return false;
+    }
+    return obj.reaction === 'dislike';
+  }
+
+  @action
+  async userChapterReaction(chapter, liked = true) {
+    if (!this.me.isAuthenticated || this.args.canReact === false) {
+      return;
+    }
+
+    console.log(this.hasDisliked,this.hasDisliked);
+
+
+    //if they have none, post
+    if (!this.hasLiked && !this.hasDisliked) {
+      return this.createUserChapterReaction(chapter, liked)
+        .then(() => {
+
+          this.updateChapterReactions(chapter, liked ? 1 : 0, liked ? 0 : 1);
+
+        }).catch(() => {
+        });
+    }
+
+    //if is the same, they have retracted it, delete/undo the reaction
+    if ((this.hasLiked && liked === true) ||
+      (this.hasDisliked && liked === false)) {
+      return this.deleteUserChapterReaction(this.currentUserReaction)
+        .then(() => {
+          this.updateChapterReactions(chapter, liked ? -1 : 0, liked ? 0 : -1);
+        }).catch(() => {
+
+        });
+    }
+
+    // if they switch, update the reaction
+    return this.updateUserChapterReaction(this.currentUserReaction, liked)
+      .then(() => {
+        this.updateChapterReactions(chapter, liked ? 1 : -1, liked ? -1 : 1);
+      }).catch(() => {
+      });
+
+  }
+
+
+  async createUserChapterReaction(chapter, liked) {
+    const model = this.store.createRecord('reaction', {
+      reaction: liked ? 'like' : 'dislike',
+      chapter: chapter,
+      user: this.me.user
+    });
+    return await model.save();
+  }
+
+  async deleteUserChapterReaction(reaction) {
+    return await reaction.destroyRecord();
+  }
+
+  async updateUserChapterReaction(reaction, liked) {
+    reaction.reaction = liked ? 'like' : 'dislike';
+    return await reaction.save();
+  }
+
+  updateChapterReactions(chapter, likesIncrement, dislikesIncrement = 0) {
+    console.log(likesIncrement, dislikesIncrement);
+    this.likes += likesIncrement;
+    this.dislikes += dislikesIncrement;
+  }
+
+}

--- a/frontend/app/models/reaction.js
+++ b/frontend/app/models/reaction.js
@@ -1,0 +1,8 @@
+import Model, {belongsTo, attr} from '@ember-data/model';
+
+export default class ReactionModel extends Model {
+
+  @attr('string') reaction;
+  @belongsTo('chapter', {inverse: null}) chapter;
+  @belongsTo('user', {inverse: null}) user;
+}

--- a/frontend/app/routes/chapter/index.js
+++ b/frontend/app/routes/chapter/index.js
@@ -11,6 +11,11 @@ export default class ChapterIndexRoute extends Route {
   }
 
   afterModel(model) {
-    return this.store.query('comment', {'chapterId': model.id});
+    return {
+      comments: this.store.query('comment', {'chapterId': model.id}),
+      //since there is no reaction ID in the model, query to return an array
+      reactions: this.me.isAuthenticated ?
+        this.store.query('reaction', {'chapterId': model.id, 'user_id': this.me.user.id}) : []
+    };
   }
 }

--- a/frontend/app/routes/chapter/index.js
+++ b/frontend/app/routes/chapter/index.js
@@ -12,10 +12,7 @@ export default class ChapterIndexRoute extends Route {
 
   afterModel(model) {
     return {
-      comments: this.store.query('comment', {'chapterId': model.id}),
-      //since there is no reaction ID in the model, query to return an array
-      reactions: this.me.isAuthenticated ?
-        this.store.query('reaction', {'chapterId': model.id, 'user_id': this.me.user.id}) : []
+      comments: this.store.query('comment', {'chapterId': model.id})
     };
   }
 }

--- a/frontend/app/routes/home.js
+++ b/frontend/app/routes/home.js
@@ -13,15 +13,9 @@ export default class HomeRoute extends Route {
   @service
   headData;
 
-  async afterModel(model) {
+  async afterModel() {
     set(this, 'headData.title', 'Wikonnect - Chapters');
     set(this, 'headData.theme', '#FF5722');
-
-    /*Get user chapter reactions if they are already authenticated*/
-    return {
-      reactions: this.me.isAuthenticated ?
-        this.store.query('reaction', {'chapterId': model.id, 'user_id': this.me.user.id}) : []
-    };
 
   }
 

--- a/frontend/app/routes/home.js
+++ b/frontend/app/routes/home.js
@@ -13,9 +13,16 @@ export default class HomeRoute extends Route {
   @service
   headData;
 
-  async afterModel() {
+  async afterModel(model) {
     set(this, 'headData.title', 'Wikonnect - Chapters');
     set(this, 'headData.theme', '#FF5722');
+
+    /*Get user chapter reactions if they are already authenticated*/
+    return {
+      reactions: this.me.isAuthenticated ?
+        this.store.query('reaction', {'chapterId': model.id, 'user_id': this.me.user.id}) : []
+    };
+
   }
 
   model() {

--- a/frontend/app/styles/_reaction-buttons.scss
+++ b/frontend/app/styles/_reaction-buttons.scss
@@ -1,0 +1,32 @@
+$palette: (
+  primary: $primary,
+  gray75: #B0BABF
+);
+
+.reaction-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: map-get($palette, gray75);
+  outline: none;
+  box-shadow: none;
+  font-size: 12px;
+  font-weight: bold;
+  font-style: normal;
+  margin: 0 14px 0 0;
+  display: inline-flex;
+  align-items: center;
+
+  span.count {
+    padding-left: 5px;
+  }
+
+  &:focus,
+  &:active {
+    outline: none;
+  }
+
+  &.active{
+    color: map-get($palette,primary);
+  }
+}

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -119,5 +119,9 @@ pre {
 //@import "ember-bootstrap/bootstrap";
 //@import "ember-power-select";
 
+
+@import "reaction-buttons";
+
+
 @import "tags-list";
 @import "custom-checkbox";

--- a/frontend/app/templates/chapter/index.hbs
+++ b/frontend/app/templates/chapter/index.hbs
@@ -6,18 +6,18 @@
   <h4>{{model.name}} </h4>
   <div class="chapter-content ">
     <H5p @location={{model.contentUri}} />
-    <div class="row">
 
-      <div class="col-6">
+    <div class="section d-flex justify-content-between pt-2 pb-2">
+      <div class="reactions">
+        <Reaction::ChapterReaction @chapter={{this.model}} @canReact={{true}}>
+
+        </Reaction::ChapterReaction>
+      </div>
+      <div class="popup-actions">
         <p> {{model.counter}} views | {{format-date model.createdAt}}</p>
       </div>
-      <div class="col-6">
-        {{!-- <Reaction @likes={{model.reaction.likes}} @dislikes={{model.reaction.dislikes}}
-          @status={{model.reaction.authenticated_user}} /> --}}
-
-
-      </div>
     </div>
+
     <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#modelId">
       Embed
     </button>
@@ -68,12 +68,12 @@
     {{#if (eq model.approved "true")}}
 
       <button {{on "click" (fn this.toggleApproval model.id "true" )}} type="button"
-        class="btn form-controll btn-danger">
+                                                                       class="btn form-controll btn-danger">
         Un Approve This
       </button>
     {{else}}
       <button {{on "click" (fn this.toggleApproval model.id "false" )}} type="button"
-        class="btn form-controll btn-success">
+                                                                        class="btn form-controll btn-success">
         Approve This
       </button>
     {{/if}}
@@ -84,14 +84,14 @@
 </div>
 
 
-
 <BsModalSimple @open={{flaggingModal}} @title="Report Chapter" @closeTitle="Close" @submitTitle="Submit Report" @size=""
-  @closeButton={{true}} @fade={{true}} @backdrop={{true}} @backdropClose={{true}} @onSubmit={{action "saveFlag" }}
-  @onHidden={{action "toggleFlaggingModal" }} @renderInPlace={{true}}>
+               @closeButton={{true}} @fade={{true}} @backdrop={{true}} @backdropClose={{true}} @onSubmit={{action
+        "saveFlag" }}
+               @onHidden={{action "toggleFlaggingModal" }} @renderInPlace={{true}}>
 
   <BsForm @model={{flagModel}} @onSubmit={{action "saveFlag" }} as |form|>
-    <form.element @controlType="textarea" @label="Reason for reporting" @property="comment" />
-    <form.element @controlType="hidden" @value={{model}} @name="chapter" />
+    <form.element @controlType="textarea" @label="Reason for reporting" @property="comment"/>
+    <form.element @controlType="hidden" @value={{model}} @name="chapter"/>
 
 
   </BsForm>
@@ -99,13 +99,13 @@
 
 
 <BsModalSimple @open={{ratingModal}} @title="Rate This Module " @closeTitle="Close"
-  @submitTitle="Submit Optional Remark" @size="" @closeButton={{true}} @fade={{true}} @backdrop={{true}}
-  @backdropClose={{true}} @onSubmit={{action "ratingSubmit" }} @onHidden={{action "toggleRatingModal" }}
-  @renderInPlace={{true}}>
+               @submitTitle="Submit Optional Remark" @size="" @closeButton={{true}} @fade={{true}} @backdrop={{true}}
+               @backdropClose={{true}} @onSubmit={{action "ratingSubmit" }} @onHidden={{action "toggleRatingModal" }}
+               @renderInPlace={{true}}>
 
   <BsForm @onSubmit={{action "ratingSubmit" }} as |form|>
     <form.element @controlType="textarea" @label="Optional reason/remark for your {{rates}} star rating"
-      @property="comment" />
+                  @property="comment"/>
 
 
   </BsForm>


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #520 

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
- Added reactions count view on homepage chapters card 
- User can like, dislike, or retract previous reaction on single chapter page