### PR TITLE
Fix #H5P library missing on backend after deployment

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^7.4.0",
     "@koa/cors": "^3.1.0",
-    "@lumieducation/h5p-server": "^7.1.0",
+    "@lumieducation/h5p-server": "^7.2.0",
     "accesscontrol": "^2.2.1",
     "async-busboy": "^1.0.1",
     "aws-sdk": "^2.643.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -160,7 +160,7 @@
   dependencies:
     stream "^0.0.2"
 
-"@lumieducation/h5p-server@^7.1.0":
+"@lumieducation/h5p-server@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@lumieducation/h5p-server/-/h5p-server-7.2.0.tgz#26a8dc5e03144d82c887e71fe15cccd7220cf403"
   integrity sha512-vNW+bEG00qxpI+rPLjiV7zzbCv+eLzO9EJNQKOOJGGoehXEK5sB8gRs2cuV4RhiRPtMGkIOLlLKaLXWXQHdg9Q==


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

### Change Log
- Freezes `@lumieducation/h5p-server` package in Yarn.lock