### PR TITLE
Revert to the integrated H5P editor

### DIFF
--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -313,6 +313,8 @@ jobs:
 
       # Frontend run build
       - name: Frontend run build
+        env:
+          GOOGLE_KEY: ${{ secrets.GOOGLE_KEY }}
         run: yarn --cwd ./frontend build --prod
 
       # Install project dependencies, test and build

--- a/frontend/app/components/teach-list-item.hbs
+++ b/frontend/app/components/teach-list-item.hbs
@@ -6,7 +6,7 @@
         <img class="card-img-top" src="https://placehold.jp/20/{{this.color}}/ffffff/328x200.png?text={{@chapter.name}}"
         alt="" role="presentation">
       {{else}}
-        <img class="card-img-top" alt="" src="/{{@chapter.imageUrl}}" role="presentation">
+        <img class="card-img-top" alt="" src="{{@chapter.imageUrl}}" role="presentation">
       {{/if}}
     </LinkTo>
 

--- a/frontend/app/controllers/chapter/index.js
+++ b/frontend/app/controllers/chapter/index.js
@@ -121,12 +121,13 @@ export default class ChapterIndexController extends Controller {
 
   @action
   async toggleApproval(chapterId, choice) {
+    let chapter = this.store.peekRecord('chapter', chapterId);
     try {
-      let chapter = this.store.peekRecord('chapter', chapterId);
       chapter.approved = choice;
       await chapter.save();
-      this.notify.alert('Chapter approval status updated successfully');
+      this.notify.success('Chapter approval status updated successfully');
     } catch (e) {
+      chapter.approved = !choice;
       this.notify.alert('Could not update chapter approval status');
     }
   }

--- a/frontend/app/controllers/teach/create.js
+++ b/frontend/app/controllers/teach/create.js
@@ -40,7 +40,7 @@ export default class TeachCreateController extends Controller {
       approved: false,
     });
     model.save().then((x) => {
-      this.transitionToRoute('teach.h5p-upload', x.id);
+      this.transitionToRoute('teach.h5p-editor', x.id);
     });
   }
 }

--- a/frontend/app/controllers/teach/h5p-editor.js
+++ b/frontend/app/controllers/teach/h5p-editor.js
@@ -26,10 +26,15 @@ export default class TeachH5pEditorController extends Controller {
       await this.model.save();
       this.transitionToRoute('teach.thumbnail-upload', this.model.id);
     } catch (e) {
-      console.log(e);
-      this.notify.alert(
-        'Unexpected error encountered and we could not save the content'
-      );
+      if (e.message && e.message.startsWith('validation-error')) {
+        this.notify.alert(
+          e.message.replace('validation-error', '').replace(':', '')
+        );
+      } else {
+        this.notify.alert(
+          'Unexpected error encountered and we could not save the content'
+        );
+      }
     }
   }
 }

--- a/frontend/app/styles/_h5p-player.scss
+++ b/frontend/app/styles/_h5p-player.scss
@@ -1,0 +1,3 @@
+.h5p-iframe-wrapper{
+  background-color: #DDD !important;
+}

--- a/frontend/app/templates/chapter/index.hbs
+++ b/frontend/app/templates/chapter/index.hbs
@@ -101,7 +101,7 @@
 
 <div class="text-center">
   {{#if (eq this.me.user.username "daph")}}
-    {{#if (eq this.model.approved "true")}}
+    {{#if (eq this.model.approved true)}}
       <button type="button" class="btn form-control btn-danger" {{on "click" (fn this.toggleApproval this.model.id false
         )}}>
         {{t "single_chapter.admin.unapprove"}}

--- a/frontend/app/templates/teach/preview.hbs
+++ b/frontend/app/templates/teach/preview.hbs
@@ -119,7 +119,7 @@
       <div>
 
         {{#if this.model.imageUrl}}
-          <img src="/{{this.model.imageUrl}}" class="img-thumbnail img-fluid rounded h-50 d-inline-block" alt={{t
+          <img src="{{this.model.imageUrl}}" class="img-thumbnail img-fluid rounded h-50 d-inline-block" alt={{t
                   "teach.preview.chapter"}}>
           <br>
           <LinkTo @route="teach.thumbnail-upload" @model={{this.model.id}}>

--- a/server/routes/chapters.js
+++ b/server/routes/chapters.js
@@ -442,8 +442,8 @@ router.post('/:id/chapter-image', async (ctx, next) => {
 
   const { files } = await busboy(ctx.req);
   const fileNameBase = shortid.generate();
-  const uploadPath = 'uploads/chapters';
-  const uploadDir = path.resolve(__dirname, '../public/' + uploadPath);
+  const uploadPath = '/uploads/chapters';
+  const uploadDir = path.resolve(__dirname, '../public' + uploadPath);
 
   ctx.assert(files.length, 400, 'No files sent.');
   ctx.assert(files.length === 1, 400, 'Too many files sent.');

--- a/server/utils/h5p/player.js
+++ b/server/utils/h5p/player.js
@@ -10,7 +10,14 @@ exports.H5PPlayer = async (editor) => {
     editor.libraryStorage,
     editor.contentStorage,
     config,
-    new H5PUrlGenerator(config)
+    null,
+    new H5PUrlGenerator(config),
+    {
+      customization: {
+        global: {
+          styles: ['/h5p/h5p-player.css']
+        }
+      }}
   );
   return player.setRenderer((model => model));
 };


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #659 

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
- Enable a way for user to inject H5P player styles
- H5P editor errors should not be vague if it's an user error
- Fixed missing images on teacher published content page
- New content chapter should be created through the integrated H5P editor
- Adds Google key to production build pipeline