### PR TITLE
[BUG] Selected  image, tags, & ratings questions still selected when creating/updating a chapter

### DIFF
--- a/frontend/app/controllers/teach/h5p-upload.js
+++ b/frontend/app/controllers/teach/h5p-upload.js
@@ -44,6 +44,9 @@ export default class TeachH5pUploadController extends Controller {
         [host, 'chapters', id, 'upload'].join('/')
       );
 
+      //reset local H5P property holder
+      this.H5PZipFile = null;
+
       this.transitionToRoute('teach.thumbnail-upload', id);
     } catch (e) {
       this.notify.alert(

--- a/frontend/app/controllers/teach/review-questions.js
+++ b/frontend/app/controllers/teach/review-questions.js
@@ -5,11 +5,7 @@ import { A } from '@ember/array';
 
 export default class ReviewQuestionsController extends Controller {
   @tracked
-  selectedCategories = A(
-    this.chapter.reviewQuestions
-      ? this.chapter.reviewQuestions
-      : this.reviewQuestionsCategories
-  );
+  selectedCategories;
 
   get chapter() {
     return this.model[0];
@@ -23,8 +19,23 @@ export default class ReviewQuestionsController extends Controller {
     return this.model[1].map((q) => q.category);
   }
 
+  get selectedQuestions() {
+    if (this.selectedCategories) {
+      return this.selectedCategories;
+    }
+    return this.reviewQuestionsCategories;
+  }
+
   @action
   categoryPreselected(category) {
+    if (!this.selectedCategories && !this.chapter.reviewQuestions) {
+      //initialize the selected categories with all review questions
+      this.selectedCategories = A(this.reviewQuestionsCategories);
+    } else if (!this.selectedCategories && this.chapter.reviewQuestions) {
+      // initialize the selected categories with existing chapter review questions
+      this.selectedCategories = A(this.chapter.reviewQuestions);
+    }
+
     if (
       this.selectedCategories.length === 0 &&
       (!this.chapter.reviewQuestions ||
@@ -50,6 +61,9 @@ export default class ReviewQuestionsController extends Controller {
     try {
       this.chapter.reviewQuestions = this.selectedCategories;
       await this.chapter.save();
+      //reset the selected questions
+      this.selectedCategories = null;
+
       this.transitionToRoute('teach.preview', this.chapter.id);
     } catch (e) {
       this.notify.alert('Request not successful. Unexpected error encountered');

--- a/frontend/app/controllers/teach/tag.js
+++ b/frontend/app/controllers/teach/tag.js
@@ -73,17 +73,23 @@ export default class TeachTagController extends Controller {
 
   @tracked custom_tags = [];
 
-  @tracked custom_cart = this.model.tags ? A(this.model.tags) : A([]);
+  @tracked custom_cart;
   @tracked tag;
 
   get selectedTags() {
-    return this.custom_cart;
+    if (this.custom_cart) {
+      return this.custom_cart;
+    }
+    return this.model.tags;
   }
 
   @action
   addtag(evt) {
     evt.preventDefault();
     evt.stopPropagation();
+    if (!this.custom_cart) {
+      this.custom_cart = A(this.model.tags);
+    }
     if (this.tag) {
       const index = this.custom_cart.findIndex(
         (pred) => pred.toLowerCase() === this.tag.toLowerCase()
@@ -99,6 +105,11 @@ export default class TeachTagController extends Controller {
 
   @action
   async updateTags() {
+    if (this.model.tags && !this.custom_cart) {
+      this.transitionToRoute('teach.review-questions', this.model.id);
+      return;
+    }
+
     let id = this.model.id;
     let combined = [];
 
@@ -113,6 +124,8 @@ export default class TeachTagController extends Controller {
     let chapter = await this.store.peekRecord('chapter', id);
     chapter.tags = combined;
     await chapter.save();
+    //reset the local tags holder
+    this.custom_cart = null;
     this.transitionToRoute('teach.review-questions', id);
   }
 
@@ -175,6 +188,9 @@ export default class TeachTagController extends Controller {
         this.kicd_list.addObject(item);
         break;
       case 'custom':
+        if (!this.custom_cart) {
+          this.custom_cart = A(this.model.tags);
+        }
         this.custom_cart.removeObject(item);
         break;
 

--- a/frontend/app/controllers/teach/thumbnail-upload.js
+++ b/frontend/app/controllers/teach/thumbnail-upload.js
@@ -54,7 +54,8 @@ export default class TeachH5pUploadController extends Controller {
       await this.uploader.startUpload(
         [host, 'chapters', id, 'chapter-image'].join('/')
       );
-
+      //reset the thumbnail local property
+      this.thumbnail = null;
       this.transitionToRoute('teach.tag', id);
     } catch (e) {
       this.notify.alert('Unexpected err encountered during thumbnail upload');

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -137,13 +137,7 @@ pre {
   height: 300px;
 }
 
-.drop-area{
-  .preview-image{
-    max-height: 300px;
-    max-width: 300px;
-    display: flex;
-  }
-}
+
 //@import "ember-bootstrap/bootstrap";
 //@import "ember-power-select";
 

--- a/frontend/app/styles/teacher/content-creation.scss
+++ b/frontend/app/styles/teacher/content-creation.scss
@@ -22,17 +22,19 @@ $palette: (
   }
 }
 
-.thumbnail-upload-section{
-  .drop-area{
-    .preview-image{
+.thumbnail-upload-section {
+  .drop-area {
+    .preview-image {
       height: 170px;
       max-width: 310px;
-      img{
-        max-width: 100%;
-        height: auto;
+      border: solid 1px map-get($palette, grey);
+      img {
+        width: auto;
+        height: 100%;
       }
     }
   }
+
 }
 
 //ratings and review section
@@ -62,4 +64,16 @@ $palette: (
     }
   }
 
+}
+
+
+@media only screen and (max-width: 600px) {
+  .thumbnail-upload-section {
+    .drop-area {
+      height: 340px;
+      .ember-file-drop-zone {
+        max-width: 15em;
+      }
+    }
+  }
 }

--- a/frontend/app/styles/teacher/content-creation.scss
+++ b/frontend/app/styles/teacher/content-creation.scss
@@ -45,6 +45,7 @@ $palette: (
       min-height: 34px;
       outline: none;
       box-shadow: none;
+      display: flex;
 
       &:hover, &:active {
         outline: none;

--- a/frontend/app/styles/teacher/content-creation.scss
+++ b/frontend/app/styles/teacher/content-creation.scss
@@ -22,6 +22,19 @@ $palette: (
   }
 }
 
+.thumbnail-upload-section{
+  .drop-area{
+    .preview-image{
+      height: 170px;
+      max-width: 310px;
+      img{
+        max-width: 100%;
+        height: auto;
+      }
+    }
+  }
+}
+
 //ratings and review section
 .review-question-section {
 

--- a/frontend/app/styles/teacher/content-creation.scss
+++ b/frontend/app/styles/teacher/content-creation.scss
@@ -8,6 +8,7 @@ $palette: (
 .content-creation-section {
   .action-buttons {
     .previous {
+      white-space: nowrap;
       margin-top: 0;
       background-color: transparent;
       color: map-get($palette, dark);
@@ -15,6 +16,7 @@ $palette: (
     }
 
     .next {
+      white-space: nowrap;
       margin-top: 0;
     }
   }

--- a/frontend/app/templates/teach/thumbnail-upload.hbs
+++ b/frontend/app/templates/teach/thumbnail-upload.hbs
@@ -11,14 +11,14 @@
     <Toc @page="3"/>
   </div>
 
-  <div class="bg-primary col-lg-6 col-sm-10 text-center p-3 text-white rounded-top">
+  <div class="bg-primary col-md-6 col-11 text-center p-3 text-white rounded-top">
     {{t "teach.thumbnail.upload"}}
   </div>
   <div class="col-12"></div>
 
   {{#if this.selectedImagePreviewSrc}}
-    <div class="drop-area col-lg-6 col-sm-10 mb-4 d-flex flex-column justify-content-center align-items-center">
-      <div class="preview-image pt-3">
+    <div class="drop-area col-md-6 col-11 mb-4 d-flex flex-column align-items-center">
+      <div class="preview-image mt-3">
         <img src="{{this.selectedImagePreviewSrc}}" class="img-fluid" role="presentation" alt="">
       </div>
 
@@ -41,7 +41,8 @@
       <p><em>*{{t "teach.thumbnail.accepted_file_types"}}</em></p>
     </div>
   {{else}}
-    <div class="drop-area col-lg-6 col-sm-10 mb-4 d-flex flex-column justify-content-center align-items-center">
+    <div
+            class="drop-area col-md-6 col-11 mb-4 d-flex align-items-center flex-column ">
 
       <File-drop-zone @onDrop={{this.onFilesSelect}}>
         <p>{{t "teach.thumbnail.drag_and_drop"}}</p>
@@ -68,7 +69,7 @@
   {{/if}}
   <div class="col-12"></div>
 
-  <div class="col-lg-6 col-sm-10 pb-5 d-flex justify-content-between mr-sm-3 ml-sm-3 action-buttons">
+  <div class="col-md-6 col-11 pb-5 d-flex justify-content-between ml-2 mr-3 m-lg-0 action-buttons">
     {{#if (or this.model.contentId (not this.model.contentUri))}}
       <LinkTo @route="teach.h5p-editor" @model={{this.model.id}}
               class="btn btn-outline-primary btn-block mr-2 previous">


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


### Change Log

- Fix chapter thumbnail selection page responsiveness on small screen devices
- Resets selected thumbnail image, tags, and review and ratings question after successful chapter update
- Fix: chapter review & rating selection buttons content overflowing on small screen devices
- Fix: chapter creation flow back & continue buttons content should not overflow on  small screen devices