### PR TITLE
fix: editing existing H5P content breaks existing images links

### DIFF
--- a/frontend/app/components/h5p/editor.js
+++ b/frontend/app/components/h5p/editor.js
@@ -45,8 +45,12 @@ export default class H5pEditorComponent extends Component {
     };
 
     element.saveContentCallback = async (contentId, requestBody) => {
-      return await fetch(`${this.baseUrl}/content`, {
-        method: 'PUT',
+      const url = contentId
+        ? `${this.baseUrl}/content/${contentId}`
+        : `${this.baseUrl}/content/`;
+
+      return await fetch(url, {
+        method: contentId ? 'PUT' : 'POST',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/server/routes/h5p.js
+++ b/server/routes/h5p.js
@@ -241,19 +241,48 @@ router.get('/content', requireAuth, async (ctx) => {
  * Persist user created content
  *
  */
-router.put('/content', requireAuth, async (ctx) => {
+router.post('/content', requireAuth, async (ctx) => {
   try {
 
-    const {contentId, library, params} = ctx.request.body;
+    const { library, params} = ctx.request.body;
     if (!params.params || !params.metadata || !library) {
-      throw 'Malformed request';
+      ctx.throw(400,{message:'Malformed request'});
     }
 
     const user = H5PUser(ctx.state.user);
     const editor = await H5PEditor();
 
     const result = await editor
-      .saveOrUpdateContentReturnMetaData(contentId || undefined, params.params, params.metadata, library, user);
+      .saveOrUpdateContentReturnMetaData( undefined, params.params, params.metadata, library, user);
+
+    ctx.status = 200;
+    ctx.body = result;
+
+  } catch (e) {
+    ctx.status = 400;
+    ctx.body = {error: e.message || e};
+  }
+});
+
+/**
+ * Persist user created content
+ *
+ */
+router.put('/content/:contentId', requireAuth, async (ctx) => {
+  try {
+
+    const {contentId} =ctx.params;
+    
+    const {library, params} = ctx.request.body;
+    if (!params.params || !params.metadata || !library) {
+      ctx.throw(400,{message:'Malformed request'});
+    }
+
+    const user = H5PUser(ctx.state.user);
+    const editor = await H5PEditor();
+
+    const result = await editor
+      .saveOrUpdateContentReturnMetaData(contentId, params.params, params.metadata, library, user);
 
     ctx.status = 200;
     ctx.body = result;

--- a/server/test/h5p.spec.js
+++ b/server/test/h5p.spec.js
@@ -207,7 +207,7 @@ describe('H5P Route', () => {
     };
     return chai
       .request(server)
-      .put(`${route}/content`)
+      .post(`${route}/content`)
       .set('content-type', 'application/json')
       .send(H5PSampleQuestion)
       .then((res) => {


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->


### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
- H5P editor will not recreate the whole content if it already exist but rather update it accordingly