### PR TITLE
Fix: Add a default JWT secret for fallback on development and test env

### DIFF
--- a/.github/ISSUE_TEMPLATE/back-end-feature.md
+++ b/.github/ISSUE_TEMPLATE/back-end-feature.md
@@ -22,7 +22,7 @@ assignees: '@mosesokemwa'
 
 
 ### Acceptance Criteria
-<!-- Detailed checlist of acceptance criteria  -->
+<!-- Detailed checklist of acceptance criteria  -->
 - [ ] eg end-point  " api/users" should not list users  for non-admin users
 - [ ] eg end-point  " api/users" should list users for admin users
 

--- a/.github/ISSUE_TEMPLATE/front-end-feature.md
+++ b/.github/ISSUE_TEMPLATE/front-end-feature.md
@@ -11,7 +11,7 @@ assignees: '@proverbial-ninja'
 <!-- eg Admin should be able to delete single or multiple users so that it is easier to manage users.  -->
 
 ### Tasks (where applicable)
-<!-- Please describe front-end tasks needed to accomplisd this-->
+<!-- Please describe front-end tasks needed to accomplished this-->
 - [ ]  eg. Fetch users from backend
 - [ ]  eg. List users on template with checkbox
 - [ ]  eg. Send delete request to backend with
@@ -22,7 +22,7 @@ assignees: '@proverbial-ninja'
 
 
 ### Acceptance Criteria
-<!-- Detailed checlist of acceptance criteria  -->
+<!-- Detailed checklist of acceptance criteria  -->
 - [ ] eg Admin Should see a list of all users
 - [ ] eg Admin Should be able to select single or multiple users
 - [ ] eg Admin Should be able to delete all selected users

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     networks:
       - wikonnect
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER}" ]
+      test: [ "CMD-SHELL", "pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,9 +14,7 @@ COPY package.json yarn.lock ./
 #Copy postinstall script
 COPY ./scripts/h5p-core-setup.js scripts/h5p-core-setup.js
 
-COPY ./.env .env
 
-RUN source .env
 
 RUN yarn --frozen-lockfile
 

--- a/server/middleware/jwt.js
+++ b/server/middleware/jwt.js
@@ -1,6 +1,6 @@
 const jwt = require('koa-jwt');
 
-const secret = process.env.SECRET;
+const secret = process.env.SECRET || '/FJYXPTv6q06Ahjm+AXXNWTW2Zy2HXSRDKjLGqYjc2I=';
 /**
  * validates and enforces token from all routes aside from users and auth
  */


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. Issue #12 will automatically get closed when this PR gets merged. -->


### Change Log

- Addition of a default JWT token
- Remove .env reference in server Dockerfile
- Pass database option when calling `pg_isready` utility on the main docker-compose.yml