### PR TITLE
[BUG] [SECURITY] Password reset endpoint shouldn't return reset token

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -153,7 +153,7 @@ router.post('/reset_password', checkIfPasswordAreSame, async ctx => {
       email: decodedMail,
     }
   );
-  ctx.assert(user, 404, user);
+  ctx.assert(user, 404, 'Account not found');
 
   try {
     const userData = await user.$query().patchAndFetch({ 'resetPasswordExpires': new Date(), 'hash': auth.hash });
@@ -162,7 +162,7 @@ router.post('/reset_password', checkIfPasswordAreSame, async ctx => {
     log.info('Password changed for user with email: %s', decodedMail);
 
     ctx.status = 201;
-    ctx.body = userData;
+    ctx.body = {};
 
   } catch (e) {
     log.info('Passwords do not match');

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -112,7 +112,7 @@ router.post('/forgot_password', async ctx => {
 
     ctx.status = 201;
     // ctx.body = userData;
-    ctx.body = { email: email, token: token };
+    ctx.body = {};
 
   } catch (e) {
     log.info('Email verification already requested');

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -205,8 +205,15 @@ router.get('/:id', permController.requireAuth, async ctx => {
   profileCompleteBoolean(user, ctx.params.id);
   log.info('Got a request from %s for %s', ctx.request.ip, ctx.path);
 
+  if(stateUserId !== userId){
+    delete user.email;
+    delete user.username;
+    delete user.updatedAt;
+    delete user.contactNumber;
+  }
+
   ctx.status = 200;
-  ctx.body = { user: user };
+  ctx.body = { user };
 });
 /**
  * @api {get} /users GET all users.


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

### Change Log

- Reset password endpoint shouldn't expose reset token
- User profile should not be returned after password reset
- Email,username, & phone number should be private
