### PR TITLE
Comment out linkedIn & facebook login buttons until 3rd party auth is fixed on production

### DIFF
--- a/frontend/app/components/authentication/login.hbs
+++ b/frontend/app/components/authentication/login.hbs
@@ -36,27 +36,27 @@
 
       <p class="line-text"><span>{{t "auth.login.or" }}</span></p>
 
-      <BsButton type="button" class="shadow-sm rounded btn-dark btn-linkedIn form-control mb-2" {{ on "click"
+      {{!-- <BsButton type="button" class="shadow-sm rounded btn-dark btn-linkedIn form-control mb-2" {{ on "click"
         this.authenticateWithLinkedIn}}>
         <span class="px-2">{{svg-jar "linkedIn-icon-2"}}</span> {{t "auth.login.login_third_party"
         authProvider="LinkedIn"}}
-      </BsButton>
+      </BsButton> --}}
 
       <BsButton type="button" class="shadow-sm border rounded btn-light form-control mb-2" {{ on "click"
         this.authenticateWithGoogleImplicitGrant}}>
         <span class="px-2">{{svg-jar "google-icon"}}</span> {{t "auth.login.login_third_party" authProvider="Google"}}
       </BsButton>
 
-      <BsButton type="button" class="shadow-sm rounded btn-dark btn-facebook form-control mb-2" {{ on "click"
+      {{!-- <BsButton type="button" class="shadow-sm rounded btn-dark btn-facebook form-control mb-2" {{ on "click"
         this.authenticateWithFacebook}}>
         <span class="px-2">{{svg-jar "facebook-icon-2"}}</span>{{t "auth.login.login_third_party"
         authProvider="Facebook"}}
-      </BsButton>
+      </BsButton> --}}
 
       {{/if}}
-      <div class="mt-2">
+      {{!-- <div class="mt-2">
         <LinkTo @route="forgot_password">{{t 'labels.forgot_password'}}</LinkTo>
-      </div>
+      </div> --}}
     </BsForm>
     <div class="d-flex justify-content-center mt-3">
       <p>{{t 'teach.login.sign_up' htmlSafe=true}}</p>

--- a/frontend/app/components/authentication/signup.hbs
+++ b/frontend/app/components/authentication/signup.hbs
@@ -54,22 +54,22 @@
 
         <p class="line-text"><span>{{t "auth.login.or" }}</span></p>
 
-        <BsButton type="button" class="shadow-sm rounded btn-dark btn-linkedIn form-control mb-2" {{ on "click"
+        {{!-- <BsButton type="button" class="shadow-sm rounded btn-dark btn-linkedIn form-control mb-2" {{ on "click"
           this.authenticateWithLinkedIn}}>
           <span class="px-2">{{svg-jar "linkedIn-icon-2"}}</span> {{t "auth.signup.signup_third_party"
           authProvider="LinkedIn"}}
-        </BsButton>
+        </BsButton> --}}
 
         <BsButton type="button" class="shadow-sm border rounded btn-light form-control mb-2" {{ on "click"
           this.authenticateWithGoogleImplicitGrant}}>
           <span class="px-2">{{svg-jar "google-icon"}}</span> {{t "auth.signup.signup_third_party" authProvider="Google"}}
         </BsButton>
 
-        <BsButton type="button" class="shadow-sm rounded btn-dark btn-facebook form-control mb-2" {{ on "click"
+        {{!-- <BsButton type="button" class="shadow-sm rounded btn-dark btn-facebook form-control mb-2" {{ on "click"
           this.authenticateWithFacebook}}>
           <span class="px-2">{{svg-jar "facebook-icon-2"}}</span>{{t "auth.signup.signup_third_party"
           authProvider="Facebook"}}
-        </BsButton>
+        </BsButton> --}}
       </BsForm>
     {{/with}}
 


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

Closes #XXXXX

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

- The LinkedIn and Facebook 3rd party auth services are missing api keys in production. I have hidden the buttons for signing in with them until this issue is fixed.