### PR TITLE
fix: Update user timestamps on creation and login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 *.envrc
 .env
 data
+*.code-workspace

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -40,10 +40,7 @@ class User extends Model {
   }
 
   $beforeInsert() {
-    this.lastSeen = new Date(+new Date());
-  }
-
-  $afterFind() {
+    super.$beforeInsert();
     this.lastSeen = new Date(+new Date());
   }
 

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -54,6 +54,11 @@ router.post('/', validateAuthRoutes.validateUserLogin, async ctx => {
   userInfoWithoutPassword['role'] = role;
 
   if (user.oauth2[0] != undefined && user.oauth2[0].userId == user.id) {
+    await user
+      .$query()
+      .findById(user.id)
+      .patch({ lastSeen: new Date(+new Date()) });
+
     ctx.body = {
       token: jsonwebtoken.sign({
         data: userInfoWithoutPassword,
@@ -61,6 +66,11 @@ router.post('/', validateAuthRoutes.validateUserLogin, async ctx => {
       }, secret)
     };
   } else if (await bcrypt.compare(ctx.request.body.password, hashPassword)) {
+    await user
+      .$query()
+      .findById(user.id)
+      .patch({ lastSeen: new Date(+new Date()) });
+      
     // eslint-disable-next-line require-atomic-updates
     ctx.body = {
       token: jsonwebtoken.sign({


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

- createdAt field is now being updated when a new user is created. 
- lastSeen field is now being updated when a user logs in