### PR TITLE
Run cypress tests in parallel to save time

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -197,6 +197,7 @@ jobs:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
+          parallel: true
 
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -193,6 +193,7 @@ jobs:
         uses: cypress-io/github-action@v2
         env:
           NODE_ENV: action
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -123,6 +123,10 @@ jobs:
   IntegrationTest:
     name: Integration Test
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5]
     services:
       # Label used to access the service container
       postgres:
@@ -140,7 +144,7 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
-    needs: FrontendTest
+    needs: [FrontendTest, BackendTest]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -198,6 +198,7 @@ jobs:
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
           parallel: true
+          record: true
 
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -200,6 +200,7 @@ jobs:
         uses: cypress-io/github-action@v2
         env:
           NODE_ENV: action
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -204,6 +204,7 @@ jobs:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
+          parallel: true
 
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -222,7 +223,7 @@ jobs:
         s3-bucket: ['wikonnect-codedeploy-deployments']
         s3-filename: ['master-wikonnect-codedeploy-${{ github.sha }}']
 
-    needs: ['IntegrationTest', 'BackendTest', 'FrontendTest']
+    needs: ['IntegrationTest']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -127,6 +127,10 @@ jobs:
   IntegrationTest:
     name: Integration Test
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5]
     services:
       # Label used to access the service container
       postgres:
@@ -145,7 +149,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    needs: FrontendTest
+    needs: [FrontendTest, BackendTest]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/master-workflow.yml
+++ b/.github/workflows/master-workflow.yml
@@ -205,6 +205,7 @@ jobs:
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
           parallel: true
+          record: true
 
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -246,6 +246,7 @@ jobs:
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
           parallel: true
+          record: true
 
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -245,6 +245,7 @@ jobs:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"
           wait-on-timeout: 120
+          parallel: true
 
       - uses: actions/upload-artifact@v1
         if: failure()
@@ -262,7 +263,7 @@ jobs:
         s3-bucket: ['wikonnect-codedeploy-deployments']
         s3-filename: ['staging-wikonnect-codedeploy-${{ github.sha }}']
 
-    needs: ['IntegrationTest', 'BackendTest']
+    needs: ['IntegrationTest']
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -168,6 +168,10 @@ jobs:
   IntegrationTest:
     name: Integration Test
     runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3, 4, 5]
     services:
       # Label used to access the service container
       postgres:
@@ -186,7 +190,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
-    needs: FrontendTest
+    needs: [FrontendTest, BackendTest]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/staging-workflow.yml
+++ b/.github/workflows/staging-workflow.yml
@@ -241,6 +241,7 @@ jobs:
         uses: cypress-io/github-action@v2
         env:
           NODE_ENV: action
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         with:
           start: yarn --cwd ./server start, yarn --cwd ./frontend start
           wait-on: "http://localhost:4200"

--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -1,3 +1,24 @@
 {
-  "projectId": "qa3kbf"
+  "projectId": "qa3kbf",
+  "baseUrl": "http://localhost:4200/",
+  "testFiles": "**/**.spec**",
+  "watchForFileChanges": true,
+  "waitForAnimations": true,
+  "numTestsKeptInMemory": 50,
+  "defaultCommandTimeout": 8000,
+  "requestTimeout": 8000,
+  "failOnStatusCode": false,
+  "video": false,
+  "screenshot": false,
+  "chromeWebSecurity": false,
+  "viewportHeight": 900,
+  "viewportWidth": 1440,
+  "reporter": "cypress-multi-reporters",
+  "reporterOptions": {
+    "configFile": "reporters/reporter-config.json"
+  },
+  "retries": {
+    "runMode": 3,
+    "openMode": 0
+  }
 }

--- a/cypress/cypress.json
+++ b/cypress/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "projectId": "qa3kbf"
+}


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [ ] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->
Used GitHub Action’s matrix feature to run cypress tests in 5 containers to decrease the amount of time to run cypress tests

