### PR TITLE
fix: disable redirect button on click to prevent multiple requests

### DIFF
--- a/frontend/app/components/modals/wifi-redirect.hbs
+++ b/frontend/app/components/modals/wifi-redirect.hbs
@@ -1,6 +1,7 @@
 <BsModal
   @open={{@showModal}}
   @closeButton={{true}}
+  @backdropClose={{false}}
   class="survey-fill-prompt-popup"
   @position="center"
   @onHide={{this.hideModal}} as |modal|
@@ -12,13 +13,14 @@
       Congratulations! You have earned 60 minutes of free internet browsing.
     </p>
     <p>Please click the button below to continue.</p>
-    <a
+    <button
       type="button"
-      role="button"
       class="btn btn-block btn-link"
       href={{@redirectUrl}}
+      disabled={{this.isRedirecting}}
+      {{on 'click' this.redirect}}
     >
-      Continue
-    </a>
+      Redeem Free Internet
+    </button>
   </modal.body>
 </BsModal>

--- a/frontend/app/components/modals/wifi-redirect.js
+++ b/frontend/app/components/modals/wifi-redirect.js
@@ -4,7 +4,7 @@ import { action } from '@ember/object';
 
 export default class WifiRedirectModalComponent extends Component {
   @tracked show = true;
-  @tracked redirectUrl = '';
+  @tracked isRedirecting = false;
 
   @action
   showModal() {
@@ -14,5 +14,12 @@ export default class WifiRedirectModalComponent extends Component {
   @action
   hideModal() {
     this.show = false;
+  }
+
+  @action
+  redirect() {
+    this.isRedirecting = true;
+    window.location.href = this.args.redirectUrl;
+    this.hideModal();
   }
 }


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Disabled redirect button in pop up to prevent users sending multiple requests to Winguapps api