### PR TITLE
Fix: logout user if authenticated and receiving a preauth token

### DIFF
--- a/frontend/app/components/modals/wifi-redirect.hbs
+++ b/frontend/app/components/modals/wifi-redirect.hbs
@@ -10,7 +10,7 @@
   <modal.body class="modal-body">
     {{!-- template-lint-disable no-bare-strings --}}
     <p>
-      Congratulations! You have earned 60 minutes of free internet browsing.
+      Congratulations on learning something new today! You have earned 60 minutes of free internet browsing.
     </p>
     <p>Please click the button below to continue.</p>
     <button

--- a/frontend/app/routes/login.js
+++ b/frontend/app/routes/login.js
@@ -11,7 +11,7 @@ export default class LoginRoute extends Route {
     },
   };
 
-  beforeModel() {
+  beforeModel(transition) {
     if (transition.to.queryParams?.preauthtoken && this.me.isAuthenticated) {
       this.me.logout();
     } else if (this.me.user) {

--- a/frontend/app/routes/login.js
+++ b/frontend/app/routes/login.js
@@ -12,7 +12,9 @@ export default class LoginRoute extends Route {
   };
 
   beforeModel() {
-    if (this.me.user) {
+    if (transition.to.queryParams?.preauthtoken && this.me.isAuthenticated) {
+      this.me.logout();
+    } else if (this.me.user) {
       this.transitionTo('index');
     }
   }


### PR DESCRIPTION
<!-- Please follow the below checklist and put an `x` in each of the boxes to agree with the statement, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [Wikonnects contributing guidelines](https://github.com/tunapanda/wikonnect/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update README.md`).
- [x] My pull request passes all tests.

<!-- If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. For e.g. Closes #12. The issue #12 will automatically get closed when this PR gets merged. -->

### Change Log

<!-- Tell us in detail about the changes you made and how it will affect the platform. -->

Added a check in the beforeModel hook for the login route to check if there's a preauth token. If there is, we logout the current user